### PR TITLE
Adding support to enable the N9300 smart switch with DPUs and Hypershield

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ module "nxos" {
 | [nxos_port_channel_interface.port_channel_interface](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/port_channel_interface) | resource |
 | [nxos_port_channel_interface_member.port_channel_interface_member](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/port_channel_interface_member) | resource |
 | [nxos_port_channel_interface_vrf.port_channel_interface_vrf](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/port_channel_interface_vrf) | resource |
+| [nxos_rest.service_acceleration](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/rest) | resource |
+| [nxos_rest.service_system_hypershield_sas_sas](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/rest) | resource |
+| [nxos_rest.service_system_hypershield_sas_svc](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/rest) | resource |
+| [nxos_rest.service_system_hypershield_sas_svc_fw_policy](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/rest) | resource |
+| [nxos_rest.service_system_hypershield_sas_svc_fw_policy_ip_vrf](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/rest) | resource |
+| [nxos_rest.service_system_hypershield_sas_svc_instance](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/rest) | resource |
+| [nxos_rest.service_system_hypershield_sas_svc_scontroller](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/rest) | resource |
 | [nxos_route_map_rule.route_map_rule](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/route_map_rule) | resource |
 | [nxos_route_map_rule_entry.route_map_rule_entry](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/route_map_rule_entry) | resource |
 | [nxos_route_map_rule_entry_match_route.route_map_rule_entry_match_route](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/route_map_rule_entry_match_route) | resource |

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ module "nxos" {
 | [nxos_rest.service_system_hypershield_sas_svc_fw_policy](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/rest) | resource |
 | [nxos_rest.service_system_hypershield_sas_svc_fw_policy_ip_vrf](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/rest) | resource |
 | [nxos_rest.service_system_hypershield_sas_svc_instance](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/rest) | resource |
+| [nxos_rest.service_system_hypershield_sas_svc_instance_delete](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/rest) | resource |
 | [nxos_rest.service_system_hypershield_sas_svc_scontroller](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/rest) | resource |
 | [nxos_route_map_rule.route_map_rule](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/route_map_rule) | resource |
 | [nxos_route_map_rule_entry.route_map_rule_entry](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/route_map_rule_entry) | resource |

--- a/nxos_feature.tf
+++ b/nxos_feature.tf
@@ -110,6 +110,15 @@ resource "nxos_feature_pvlan" "pvlan" {
   admin_state = try(local.device_config[each.key].system.feature.pvlan, local.defaults.nxos.devices.configuration.system.feature.pvlan) ? "enabled" : "disabled"
 }
 
+resource "nxos_rest" "service_acceleration" {
+  for_each   = { for device in local.devices : device.name => device if try(local.device_config[device.name].system.feature.service_acceleration, local.defaults.nxos.devices.configuration.system.feature.service_acceleration, null) != null }
+  dn         = "sys/fm/serviceacceleration"
+  class_name = "fmServiceAcceleration"
+  content = {
+    adminSt : try(local.device_config[each.key].system.feature.service_acceleration, local.defaults.nxos.devices.configuration.system.feature.service_acceleration) ? "enabled" : "disabled"
+  }
+}
+
 resource "nxos_feature_ssh" "ssh" {
   for_each    = { for device in local.devices : device.name => device if try(local.device_config[device.name].system.feature.ssh, local.defaults.nxos.devices.configuration.system.feature.ssh, null) != null }
   device      = each.key

--- a/nxos_service_hypershield.tf
+++ b/nxos_service_hypershield.tf
@@ -1,0 +1,118 @@
+locals {
+  service_hypershield = flatten([
+    for device in local.devices : [
+      {
+        key                = format("%s", device.name)
+        device             = device.name
+        source_interface   = try(local.device_config[device.name].hypershield.source_interface, null)
+        https_proxy_port   = try(local.device_config[device.name].hypershield.https_proxy_port, null)
+        https_proxy_server = try(local.device_config[device.name].hypershield.https_proxy_server, null)
+        admin_state        = try(local.device_config[device.name].hypershield.admin_state == "in-service" || local.device_config[device.name].hypershield.admin_state == null ? "in-service" : local.device_config[device.name].hypershield.admin_state, null)
+        vrfs               = try(local.device_config[device.name].hypershield.vrfs, [])
+    }]
+  ])
+
+}
+
+
+resource "nxos_rest" "service_system_hypershield_sas_sas" {
+  for_each = { for v in local.service_hypershield : v.key => v }
+
+  dn         = "sys/sas"
+  class_name = "sasSas"
+
+}
+
+resource "nxos_rest" "service_system_hypershield_sas_svc" {
+  for_each = { for v in local.service_hypershield : v.key => v }
+
+  dn         = "sys/sas/svc"
+  class_name = "sasSvc"
+
+  depends_on = [nxos_rest.service_system_hypershield_sas_sas]
+
+}
+
+resource "nxos_rest" "service_system_hypershield_sas_svc_instance" {
+  for_each = { for v in local.service_hypershield : v.key => v }
+
+  dn         = "sys/sas/svc/svcinst-hypershield"
+  class_name = "sasSvcInstance"
+
+  content = {
+    cpSrcInterface = each.value.source_interface
+    name           = "hypershield" # This is the sevice name and must be set to hypershield - This line refers to the "service system hypershield" command
+  }
+
+  depends_on = [nxos_rest.service_system_hypershield_sas_svc]
+}
+
+resource "nxos_rest" "service_system_hypershield_sas_svc_scontroller" {
+  for_each = { for v in local.service_hypershield : v.key => v }
+
+  dn         = "sys/sas/svc/svcinst-hypershield/scontroller"
+  class_name = "sasSController"
+  content = {
+    httpsProxyPort = each.value.https_proxy_port
+    httpsProxySvr  = each.value.https_proxy_server
+  }
+
+  depends_on = [nxos_rest.service_system_hypershield_sas_svc_instance]
+
+}
+
+resource "nxos_rest" "service_system_hypershield_sas_svc_fw_policy" {
+  for_each = { for v in local.service_hypershield : v.key => v }
+
+  dn         = "sys/sas/svc/svcinst-hypershield/fwpolicy"
+  class_name = "sasFwSvcPolicy"
+  content = {
+    adminState = each.value.admin_state
+  }
+
+  lifecycle {
+    precondition {
+      condition     = each.value.admin_state == "in-service" || each.value.admin_state == null
+      error_message = "Allowed values: `in-service` or null"
+    }
+  }
+
+
+  depends_on = [nxos_rest.service_system_hypershield_sas_svc_instance]
+
+}
+
+locals {
+  service_hypershield_vrfs = flatten([
+    for device in local.devices : [
+      for vrf in try(local.device_config[device.name].hypershield.vrfs, []) : {
+        key      = format("%s_vrf_%s", device.name, vrf.name)
+        device   = device.name
+        vrf_name = vrf.name
+        affinity = try(contains([0, 1, 2, 3, 4], vrf.affinity) ? vrf.affinity : (vrf.affinity == "dynamic" || vrf.affinity == null ? "0" : vrf.affinity), "0")
+      }
+    ]
+  ])
+}
+
+
+resource "nxos_rest" "service_system_hypershield_sas_svc_fw_policy_ip_vrf" {
+  for_each = { for v in local.service_hypershield_vrfs : v.key => v }
+
+  dn         = "sys/sas/svc/svcinst-hypershield/fwpolicy/ipvrf/dom-[${each.value.vrf_name}]"
+  class_name = "sasDom"
+  content = {
+    name     = each.value.vrf_name
+    affinity = each.value.affinity
+  }
+
+  lifecycle {
+    precondition {
+      condition     = contains(["0", "1", "2", "3", "4", null, "dynamic"], each.value.affinity)
+      error_message = "Allowed values: 1, 2, 3, 4. For dynamic affinity use `dynamic`, 0, or null"
+    }
+  }
+
+  depends_on = [nxos_rest.service_system_hypershield_sas_svc_fw_policy]
+
+}

--- a/nxos_service_hypershield.tf
+++ b/nxos_service_hypershield.tf
@@ -107,8 +107,8 @@ locals {
         device      = device.name
         vrf_name    = vrf.name
         affinity = (
-          contains([0, 1, 2, 3, 4], vrf.affinity) ? vrf.affinity :
-          (vrf.affinity == "dynamic" || vrf.affinity == null ? "0" : vrf.affinity)
+          try(contains([0, 1, 2, 3, 4], vrf.affinity) ? vrf.affinity :
+          (vrf.affinity == "dynamic" ? "0" : vrf.affinity), null)
         )
       }
     ]
@@ -127,7 +127,11 @@ resource "nxos_rest" "service_system_hypershield_sas_svc_fw_policy_ip_vrf" {
 
   lifecycle {
     precondition {
-      condition     = contains(["0", "1", "2", "3", "4", null, "dynamic"], each.value.affinity)
+      condition = (
+        each.value.affinity == null ? true : (
+          contains(["0", "1", "2", "3", "4", "dynamic"], each.value.affinity)
+        )
+      )
       error_message = "Allowed values: 1, 2, 3, 4. For dynamic affinity use `dynamic`, 0"
     }
   }


### PR DESCRIPTION
This adds support to enable the DPUs on the smart switch and is the equivalent of:

```
feature service-acceleration

service system hypershield
  https-proxy proxy.example.com port 80
  source-interface loopback100
  service firewall
    vrf red module-affinity dynamic
    vrf green module-affinity 3
    in-service
```

Here is an example configuration

```yaml
nxos:
  devices:
    - name: n9300-smart-switch
      url: https://10.1.1.1
      configuration:
        system:
          feature:
            service_acceleration: true
        hypershield:
          source_interface: "loopback100"
          https_proxy_port: 80
          https_proxy_server: "example.my-proxy.com"
          admin_state: "in-service"
          vrfs:
            - name: green
              affinity: 1
            - name: blue
              affinity: dynamic
            - name: red
```