### PR TITLE
Add object-group support (nxos_object_group)

### DIFF
--- a/.changelog/add-object-group-support.md
+++ b/.changelog/add-object-group-support.md
@@ -1,0 +1,1 @@
+- Add object group support (`ipv4_address_object_groups`, `ipv6_address_object_groups`, `port_object_groups`) rendered into the `nxos_object_group` resource

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ No outputs.
 | [nxos_network_qos.network_qos](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/network_qos) | resource |
 | [nxos_ntp.ntp](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/ntp) | resource |
 | [nxos_nvo.nvo](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/nvo) | resource |
+| [nxos_object_group.object_group](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/object_group) | resource |
 | [nxos_ospf.ospf](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/ospf) | resource |
 | [nxos_ospfv3.ospfv3](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/ospfv3) | resource |
 | [nxos_physical_interface.physical_interface](https://registry.terraform.io/providers/CiscoDevNet/nxos/latest/docs/resources/physical_interface) | resource |

--- a/main.tf
+++ b/main.tf
@@ -125,6 +125,7 @@ resource "nxos_cli" "cli_0" {
     nxos_network_qos.network_qos,
     nxos_ntp.ntp,
     nxos_nvo.nvo,
+    nxos_object_group.object_group,
     nxos_ospf.ospf,
     nxos_ospfv3.ospfv3,
     nxos_physical_interface.physical_interface,

--- a/nxos_access_list.tf
+++ b/nxos_access_list.tf
@@ -157,6 +157,7 @@ resource "nxos_access_list" "access_list" {
   ingress_vty_access_list_name = try(local.device_config[each.key].system.line_vty_access_class_in, null)
   egress_vty_access_list_name  = try(local.device_config[each.key].system.line_vty_access_class_out, null)
   depends_on = [
+    nxos_object_group.object_group,
     nxos_physical_interface.physical_interface,
     nxos_svi_interface.svi_interface,
     nxos_loopback_interface.loopback_interface,

--- a/nxos_object_group.tf
+++ b/nxos_object_group.tf
@@ -1,0 +1,31 @@
+resource "nxos_object_group" "object_group" {
+  for_each = { for device in local.devices : device.name => device
+    if length(try(local.device_config[device.name].ipv4_address_object_groups, [])) > 0 ||
+    length(try(local.device_config[device.name].ipv6_address_object_groups, [])) > 0 ||
+  length(try(local.device_config[device.name].port_object_groups, [])) > 0 }
+  device = each.key
+
+  ipv4_address_object_groups = length(try(local.device_config[each.key].ipv4_address_object_groups, [])) > 0 ? { for og in try(local.device_config[each.key].ipv4_address_object_groups, []) : og.name => {
+    members = length(try(og.members, [])) > 0 ? { for m in try(og.members, []) : m.sequence_number => {
+      prefix        = try(m.prefix, null)
+      prefix_length = try(tostring(m.prefix_length), null)
+      prefix_mask   = try(m.prefix_mask, null)
+    } } : null
+  } } : null
+
+  ipv6_address_object_groups = length(try(local.device_config[each.key].ipv6_address_object_groups, [])) > 0 ? { for og in try(local.device_config[each.key].ipv6_address_object_groups, []) : og.name => {
+    members = length(try(og.members, [])) > 0 ? { for m in try(og.members, []) : m.sequence_number => {
+      prefix        = try(m.prefix, null)
+      prefix_length = try(tostring(m.prefix_length), null)
+      prefix_mask   = try(m.prefix_mask, null)
+    } } : null
+  } } : null
+
+  port_object_groups = length(try(local.device_config[each.key].port_object_groups, [])) > 0 ? { for og in try(local.device_config[each.key].port_object_groups, []) : og.name => {
+    members = length(try(og.members, [])) > 0 ? { for m in try(og.members, []) : m.sequence_number => {
+      port_operator = try(m.port_operator, null)
+      port_1        = try(tostring(m.port_1), null)
+      port_2        = try(tostring(m.port_2), null)
+    } } : null
+  } } : null
+}


### PR DESCRIPTION
> **Draft — depends on [CiscoDevNet/terraform-provider-nxos#511](https://github.com/CiscoDevNet/terraform-provider-nxos/pull/511).** CI (`terraform validate`) will not pass until that PR is merged and released and `versions.tf` is bumped to a provider version that includes the `nxos_object_group` resource. Opening as a draft so the module change can be reviewed alongside the provider change.

### Description

Adds object-group support to the module, rendering three new data-model keys into the provider's `nxos_object_group` resource:

| YAML key | Provider attribute | Members |
|---|---|---|
| `ipv4_address_object_groups` | `ipv4_address_object_groups` | `sequence_number`, `prefix`, `prefix_length` \| `prefix_mask` |
| `ipv6_address_object_groups` | `ipv6_address_object_groups` | `sequence_number`, `prefix`, `prefix_length` \| `prefix_mask` |
| `port_object_groups` | `port_object_groups` | `sequence_number`, `port_operator`, `port_1`, `port_2` |

These are the object groups that `nxos_access_list` already references via `source_address_group` / `destination_address_group` / `source_port_group` / `destination_port_group`. `nxos_access_list` now `depends_on` `nxos_object_group` so groups exist before ACL entries reference them.

Closes #172.

### Example

```yaml
ipv4_address_object_groups:
  - name: OG_WEB_SRV
    members:
      - { sequence_number: 10, prefix: 192.168.10.0, prefix_length: 24 }
      - { sequence_number: 20, prefix: 10.0.0.5, prefix_mask: 0.0.0.0 }
port_object_groups:
  - name: OG_WEB_PORTS
    members:
      - { sequence_number: 10, port_operator: eq, port_1: 443 }
      - { sequence_number: 20, port_operator: range, port_1: 8000, port_2: 8100 }
```

### Changes

- `nxos_object_group.tf` (new) — renders the three keys, mirroring the structure/conventions of `nxos_access_list.tf`.
- `nxos_access_list.tf` — add `nxos_object_group.object_group` to `depends_on`.
- `.changelog/add-object-group-support.md` — changelog fragment.
- `README.md` — regenerated with `terraform-docs` (adds the resource to the Resources table).

### Testing

The identical wiring was validated in a downstream consumer against a live Nexus 93180YC-FX3: `terraform validate` passes against a provider built from CiscoDevNet/terraform-provider-nxos#511, and that provider's own acceptance tests (`TestAccNxosObjectGroup`, `TestAccDataSourceNxosObjectGroup`) pass on the same device.

Once the provider release is available, `versions.tf` should be bumped to require it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
